### PR TITLE
Add --example-workers 0 to read-only doccmd hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,7 +128,8 @@ repos:
         stages: [pre-push]
       - id: interrogate-docs
         name: interrogate docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="interrogate"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -150,7 +151,8 @@ repos:
         require_serial: true
       - id: mypy-docs
         name: mypy-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="mypy"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -165,7 +167,8 @@ repos:
         require_serial: true
       - id: pylint-docs
         name: pylint-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pylint"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pylint"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -188,7 +191,8 @@ repos:
         require_serial: true
       - id: pyright-docs
         name: pyright-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="pyright"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pyright"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -247,8 +251,8 @@ repos:
         stages: [pre-commit]
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=shell --language=console
-          --command="shellcheck --shell=bash"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell
+          --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -291,7 +295,8 @@ repos:
         stages: [pre-push]
       - id: vulture-docs
         name: vulture docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="vulture"
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="vulture"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
## Summary
- Add `--example-workers 0` to all doccmd hooks using `--no-write-to-file`

## Benefits
- Enables parallel processing of code blocks in documentation
- Significantly speeds up linter hooks (mypy, pyright, shellcheck, vulture, etc.)
- Auto-detects optimal worker count based on CPU cores

## Details
The `--example-workers 0` flag enables doccmd to process multiple code blocks concurrently when running read-only linters. This is safe because these hooks use `--no-write-to-file`, which means they only emit diagnostics without modifying files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)