### PR TITLE
Pin pytest-beartype-tests to 2026.4.20 on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,8 +100,6 @@ bdist_wheel.universal = true
 [tool.setuptools_scm]
 version_scheme = "post-release"
 
-[tool.uv]
-
 [tool.ruff]
 line-length = 79
 lint.select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "pytest-regressions==2.10.0",
     "pyyaml==6.0.3",
@@ -101,7 +101,6 @@ bdist_wheel.universal = true
 version_scheme = "post-release"
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
Replace the temporary `[tool.uv.sources]` git pin to bc81d99 with the published PyPI release `pytest-beartype-tests==2026.4.20` (same Sybil-safe plugin behavior).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency metadata-only change limited to dev/test tooling; no runtime code paths are affected.
> 
> **Overview**
> Pins the dev dependency `pytest-beartype-tests` to the published PyPI version `2026.4.20` instead of leaving it unversioned.
> 
> Removes the temporary `[tool.uv]` git source override that previously pinned `pytest-beartype-tests` to a specific commit, simplifying dependency resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98f4cf919df0b48b3c5746e91ca7a2baaf0e43e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->