### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ optional-dependencies.dev = [
     "furo==2025.12.19",
     "hypothesis==6.152.4",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "packaging>=24.0",
     "prek==0.3.13",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates a dev-only type-checking dependency and does not change runtime code, though it may introduce new/changed type-checking diagnostics in CI.
> 
> **Overview**
> Updates the development dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd12f4bb98d61725510c3cf7c63b93fc9ecaf03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->