### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -187,6 +187,7 @@ repos:
       - id: mypy
         name: mypy
         entry: uv run --extra=dev mypy
+        args: [--num-workers=4]
         language: python
         types_or: [python]
         additional_dependencies: [*uv_version]
@@ -197,6 +198,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        args: [--num-workers=4]
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -197,8 +197,8 @@ repos:
       # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
         name: mypy-docs
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
-        args: [--num-workers=4]
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -186,8 +186,7 @@ repos:
 
       - id: mypy
         name: mypy
-        entry: uv run --extra=dev mypy
-        args: [--num-workers=4]
+        entry: uv run --extra=dev mypy --num-workers=4
         language: python
         types_or: [python]
         additional_dependencies: [*uv_version]


### PR DESCRIPTION
## Summary
- Add `--num-workers=4` to the `mypy` pre-commit hook args.
- Add `--num-workers=4` to the `mypy-docs` pre-commit hook args.

## Test plan
- Ran `pre-commit validate-config`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects developer tooling performance; behavior of type checking is largely unchanged aside from potential nondeterministic ordering/timing in output.
> 
> **Overview**
> Speeds up pre-push type checking by running `mypy` with `--num-workers=4` in the `mypy` pre-commit hook.
> 
> Applies the same parallelism setting to the `mypy-docs` hook by passing `--num-workers=4` through the `doccmd` `--command` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09572b27c835d0e4b1a3615678270ed9309ea562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->