### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ ci:
     - shfmt-docs
     - spelling
     - sphinx-lint
+    - strict-kwargs-fix
     - ty
     - ty-docs
     - pyrefly
@@ -334,6 +335,16 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python, pyi]
+        additional_dependencies: [*uv_version]
+        stages: [pre-commit]
+        require_serial: true
 
       - id: shellcheck
         name: shellcheck

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -336,7 +336,6 @@ repos:
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
     "beartype>=0.22.9",
     "click>=8.3.1",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",
@@ -78,6 +79,7 @@ optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
+
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/click-compose"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.36",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
     "beartype>=0.22.9",
     "click>=8.3.1",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
-
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/click-compose"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ dependencies = [
     "beartype>=0.22.9",
     "click>=8.3.1",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling (pre-commit config and dev dependency list) and do not affect runtime behavior, though they may introduce new auto-fixes on commit.
> 
> **Overview**
> **Adds a new pre-commit autofix step** by registering a local `strict-kwargs-fix` hook (`uv run --extra=dev strict-kwargs fix`) that runs on `pre-commit` for Python files and is marked `require_serial`.
> 
> **Updates tooling deps/CI behavior** by adding `strict-kwargs==2026.5.18.post1` to `optional-dependencies.dev` and including `strict-kwargs-fix` in the pre-commit CI `skip` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea9462b1f5c7feb0b14de8f5f46429d69f823d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->