### PR TITLE
Ban dynamic builtins and typing.cast in lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ lint.per-file-ignores."tests/*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
@@ -167,6 +168,17 @@ MASTER.load-plugins = [
     "pylint.extensions.typing",
 ]
 MASTER.unsafe-load-any-extension = false
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
+]
 "MESSAGES CONTROL".enable = [
     "bad-inline-option",
     "deprecated-pragma",


### PR DESCRIPTION
## Summary
- Add literalizer DEPRECATED_BUILTINS.bad-functions pylint config (filter, getattr, hasattr, map, setattr).
- Ban typing.cast imports via ruff flake8-tidy-imports where the project uses ruff.
- Fix or pylint-disable existing violations uncovered by the new rules.

## Test plan
- [ ] CI lint passes (pylint, ruff, pre-commit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only configuration changes that may introduce new CI failures where `typing.cast` or banned builtins are still used, but do not affect runtime behavior.
> 
> **Overview**
> Tightens linting rules by **banning `typing.cast`** via Ruff (`flake8-tidy-imports`) and **flagging dynamic builtin usage** (`filter`, `map`, `getattr`, `setattr`, `hasattr`) via Pylint’s `DEPRECATED_BUILTINS.bad-functions`.
> 
> This PR is purely config-level and is intended to force safer, more explicit type narrowing and attribute access patterns going forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af665159022fa05e416e9b7d0a7157151d4d5b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->