### PR TITLE
[codex] Drive changelog releases from towncrier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,41 +53,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get the changelog underline
-        id: changelog_underline
+      # towncrier writes the rendered notes to stdout (informational
+      # chatter goes to stderr), so this is the curated release body for
+      # this version, not github-tag-action's commit-derived changelog.
+      - name: Generate the GitHub release notes
         env:
           RELEASE: ${{ steps.calver.outputs.release }}
-        run: |
-          underline="$(echo "$RELEASE" | tr -c '\n' '-')"
-          echo "underline=${underline}" >> "$GITHUB_OUTPUT"
+        run: uv run --extra=release towncrier build --draft --version "$RELEASE" >
+          release-notes.md
 
-      - name: Update changelog
-        id: update_changelog
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "Next\n----"
-          replace: |
-            Next
-            ----
-
-            ${{ steps.calver.outputs.release }}
-            ${{ steps.changelog_underline.outputs.underline }}
-          include: CHANGELOG.rst
-          regex: false
-
-      - name: Check Update changelog was modified
+      # Assemble the same fragments into CHANGELOG.rst under a new
+      # ``$RELEASE`` section and delete the consumed fragment files.
+      - name: Update the changelog
         env:
-          MODIFIED_FILES: ${{ steps.update_changelog.outputs.modifiedFiles }}
-        run: |
-          if [ "$MODIFIED_FILES" = "0" ]; then
-            echo "Error: No files were modified when updating changelog"
-            exit 1
-          fi
+          RELEASE: ${{ steps.calver.outputs.release }}
+        run: uv run --extra=release towncrier build --yes --version "$RELEASE"
+
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit
         with:
           commit_message: Bump CHANGELOG
-          file_pattern: CHANGELOG.rst
+          file_pattern: CHANGELOG.rst newsfragments
           # Error if there are no changes.
           skip_dirty_check: true
 
@@ -127,4 +113,4 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           makeLatest: true
           name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          bodyFile: release-notes.md

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,7 @@
 Changelog
 =========
 
-Next
-----
-
-- Drop Python 3.10 support (requires Python >=3.11).
+.. towncrier release notes start
 
 2025.10.27.3
 ------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,8 +22,17 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinxcontrib.spelling",
+    "sphinxcontrib.towncrier.ext",
     "sphinx_substitution_extensions",
 ]
+
+# Render the unreleased ``newsfragments/`` entries into
+# ``docs/source/unreleased.rst`` so the Sphinx spelling, doc-build and
+# link-checking gates cover the prose before it is assembled into
+# CHANGELOG.rst at release time.
+towncrier_draft_autoversion_mode = "draft"
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = f"{_pyproject_file.parent}"
 
 templates_path = ["_templates"]
 source_suffix = ".rst"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,4 +23,5 @@ Reference
 
    install
    usage
+   unreleased
    changelog

--- a/docs/source/unreleased.rst
+++ b/docs/source/unreleased.rst
@@ -1,0 +1,8 @@
+Unreleased changes
+==================
+
+Changes that have landed on the main branch but are not yet part of a
+tagged release.  These entries are assembled into the
+:doc:`changelog` when the next release is published.
+
+.. towncrier-draft-entries::

--- a/docs/towncrier_template.rst.jinja
+++ b/docs/towncrier_template.rst.jinja
@@ -1,0 +1,14 @@
+
+{% for section_name, section in sections.items() %}
+{% if section %}
+{% for category, entries in section.items() %}
+{% for text, _ in entries.items() %}
+- {{ text }}
+
+{% endfor %}
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/newsfragments/+migrated-next.change.rst
+++ b/newsfragments/+migrated-next.change.rst
@@ -1,0 +1,1 @@
+Drop Python 3.10 support (requires Python >=3.11).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,11 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
+    # ``sphinxcontrib-towncrier`` renders unreleased news fragments
+    # into docs/source/unreleased.rst during Sphinx builds.
+    "sphinxcontrib-towncrier==0.5.0a0",
     "strict-kwargs==2026.5.19.post3",
+    "towncrier==25.8.0",
     "ty==0.0.38",
     "vulture==2.16",
     "yamlfix==1.19.1",
@@ -227,6 +231,8 @@ ignore = [
     ".pre-commit-config.yaml",
     ".prettierrc",
     "CHANGELOG.rst",
+    "newsfragments",
+    "newsfragments/**",
     "LICENSE",
     "Makefile",
     "ci",
@@ -282,6 +288,30 @@ report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
 report.show_missing = true
+
+[tool.towncrier]
+# The changelog and the per-release GitHub release notes are both built
+# from news fragments under ``newsfragments/``.  The release workflow
+# runs ``towncrier build`` to assemble them; contributors add one
+# fragment file per user-facing change.
+directory = "newsfragments"
+filename = "CHANGELOG.rst"
+# Custom template so an assembled version reproduces the historical
+# style exactly: a bare ``<version>`` heading (no project name, no
+# date) followed by a flat bullet list with no per-type sub-headings.
+template = "docs/towncrier_template.rst.jinja"
+title_format = "{version}"
+# ``title_format`` underline first, then any nested headings.  A bare
+# version such as ``2026.05.18`` underlined with ``-`` matches every
+# pre-towncrier entry in CHANGELOG.rst.
+underlines = [ "-", "~", "^" ]
+issue_format = "#{issue}"
+type = [
+    # A single, unnamed fragment type keeps the assembled output as one
+    # flat bullet list, matching the historical changelog (which never
+    # grouped entries under "Features"/"Bugfixes"/... sub-headings).
+    { directory = "change", name = "", showcontent = true },
+]
 
 [tool.pydocstringformatter]
 write = true
@@ -341,6 +371,9 @@ ignore_names = [
     "warning_is_error",
     # Example commands in documentation
     "cmd",
+    "towncrier_draft_autoversion_mode",
+    "towncrier_draft_include_empty",
+    "towncrier_draft_working_directory",
 ]
 exclude = [ ".venv" ]
 


### PR DESCRIPTION
## Summary

This switches release changelog handling to the same towncrier-based flow used by literalizer:

- replace the manual `Next` changelog section update with `towncrier build`
- generate GitHub release notes from the same news fragments
- add the towncrier config, template, and `newsfragments/` directory
- render unreleased fragments in docs where the project has Sphinx docs
- migrate any existing `Next` entries into initial news fragments

## Validation

- `uv run --extra=release towncrier build --draft --version 2099.01.01`
- `uvx --from actionlint-py actionlint .github/workflows/release.yml`
- `uv run --extra=dev pyproject-fmt --check --no-print-diff pyproject.toml` where the repo has a dev extra
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release automation now generates tags’ release notes and updates `CHANGELOG.rst` via `towncrier`, so misconfiguration or template issues could break the release workflow or changelog generation. Docs builds also start rendering draft fragments, which may introduce new Sphinx/spelling/linkcheck failures.
> 
> **Overview**
> **Release notes and changelog generation are migrated to `towncrier`.** The release workflow now builds `release-notes.md` from `newsfragments/` and uses it as the GitHub Release body, and it updates `CHANGELOG.rst` by running `towncrier build` (committing both the changelog and consumed fragments) instead of editing a manual `Next` section.
> 
> **Docs and project config are updated to support the new flow.** Adds `towncrier` configuration and a custom template in `pyproject.toml`, introduces `newsfragments/` with a migrated entry, and extends Sphinx to render an `unreleased` page from draft fragments during documentation builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f249a5fd962e5aa390f2ddfc2497e8f30a0910f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->