### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -390,7 +390,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -388,3 +388,9 @@ repos:
         types_or: [yaml]
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -305,6 +305,15 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies: [*uv_version]
+        stages: [pre-commit]
+        require_serial: true
+
       - id: shellcheck
         name: shellcheck
         entry: uv run --extra=dev shellcheck
@@ -387,10 +396,4 @@ repos:
         pass_filenames: false
         types_or: [yaml]
         additional_dependencies: [*uv_version]
-        stages: [pre-commit]
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
         stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ lint.per-file-ignores."tests/*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [ "NOD" ]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
@@ -383,3 +384,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "packaging>=24.0",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes to lint and CI hooks; no runtime library behavior.
> 
> **Overview**
> Adds **`no-defaults`** (`1.0.1`) to dev dependencies and wires a **pre-commit** hook (`uv run --extra=dev no-defaults`) alongside existing local linters like `strict-kwargs`.
> 
> Configures **`[tool.no_defaults]`** with `private_only = true` (no defaults on private functions/classes/modules in non-test code) and **`per_file_enforcement."tests/**" = "all"`** (no parameter defaults anywhere under tests). Registers Ruff **`lint.external = ["NOD"]`** so `NOD` noqa suppressions are recognized when the checker and Ruff run together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08dcafa09368ec52d105c7ccedc12bbcef9f2c0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->