### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.22.9",
+    "beartype==0.23.0rc0",
     "click>=8.3.1",
 ]
 optional-dependencies.dev = [


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no application logic edits; risk is limited to possible beartype RC behavior differences on `@beartype`-decorated public APIs, and the pin is explicitly not for production merge as-is.
> 
> **Overview**
> **Pins the runtime `beartype` dependency** from `beartype>=0.22.9` to **`beartype==0.23.0rc0`** in `pyproject.toml` so CI and local installs exercise the [0.23.0 release candidate](https://pypi.org/project/beartype/0.23.0rc0/) against this repo’s tests (including `pytest-beartype-tests`).
> 
> This is a **temporary, evaluation-only** change: the PR is not meant to merge with a hard pin on an RC; the constraint should be relaxed once the RC is validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa320dd37936a87c6c8df37b78889a4fb1f7148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->