### PR TITLE
Bump mypy-strict-kwargs to 2026.8.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ optional-dependencies.dev = [
     "hypothesis==6.165.10",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.1",
-    "mypy-strict-kwargs==2026.8.20.1",
+    "mypy-strict-kwargs==2026.8.25",
     "no-defaults==2.1.0",
     "packaging>=24.0",
     "prek==0.4.14",
@@ -392,8 +392,3 @@ whitelines = 1
 [tool.no_defaults]
 private_only = true
 per_file_enforcement."tests/**" = "all"
-
-[tool.mypy_strict_kwargs]
-ignore_names = [
-    "beartype._decor.decorcache.beartype",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ optional-dependencies.dev = [
     "hypothesis==6.165.10",
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.1",
-    "mypy-strict-kwargs==2026.8.25",
+    "mypy-strict-kwargs==2026.8.25.1",
     "no-defaults==2.1.0",
     "packaging>=24.0",
     "prek==0.4.14",


### PR DESCRIPTION
`mypy-strict-kwargs` 2026.08.20.1 shipped two regressions, fixed in
2026.8.25 by https://github.com/adamtheturtle/mypy-strict-kwargs/pull/796:

- Its `get_attribute_hook` claimed every attribute name and so shadowed
  mypy's own default-plugin hooks, which is what gives `SomeEnum.value`
  its real type; every enum `.value` access degraded to `Any`.
- The new overloaded-call `call-arg` check reported decorator
  applications such as `@beartype`, which have no keyword form.

This bumps the pin and drops the `ignore_names` opt-outs that were added
for the second regression. Verified locally: mypy is clean without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACFJDTrtojHAEbXRGoxAg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only typing plugin pin and config cleanup with no runtime or production dependency impact.
> 
> **Overview**
> Upgrades the dev dependency **`mypy-strict-kwargs`** from `2026.8.20.1` to `2026.8.25.1`, picking up fixes for two regressions in the previous release (overly broad attribute hooks breaking enum `.value` typing, and false **`call-arg`** reports on decorator uses like `@beartype`).
> 
> Removes the **`[tool.mypy_strict_kwargs]`** `ignore_names` workaround for `beartype._decor.decorcache.beartype` now that the plugin no longer flags those applications; mypy still loads **`mypy_strict_kwargs`** via **`[tool.mypy]`** plugins unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311711bf3f6222aaa8bedf2116bf69b0dfe6bfb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->